### PR TITLE
Fix schedulable flag for OpenAI and Azure accounts

### DIFF
--- a/src/services/azureOpenaiAccountService.js
+++ b/src/services/azureOpenaiAccountService.js
@@ -296,7 +296,11 @@ async function getAllAccounts() {
         }
       }
 
-      accounts.push(accountData)
+      accounts.push({
+        ...accountData,
+        isActive: accountData.isActive === 'true',
+        schedulable: accountData.schedulable !== 'false'
+      })
     }
   }
 

--- a/src/services/openaiAccountService.js
+++ b/src/services/openaiAccountService.js
@@ -502,6 +502,8 @@ async function getAllAccounts() {
       // 不解密敏感字段，只返回基本信息
       accounts.push({
         ...accountData,
+        isActive: accountData.isActive === 'true',
+        schedulable: accountData.schedulable !== 'false',
         openaiOauth: accountData.openaiOauth ? '[ENCRYPTED]' : '',
         accessToken: accountData.accessToken ? '[ENCRYPTED]' : '',
         refreshToken: accountData.refreshToken ? '[ENCRYPTED]' : '',


### PR DESCRIPTION
## Summary
- Convert `isActive` and `schedulable` fields to booleans when returning OpenAI accounts
- Convert `isActive` and `schedulable` fields to booleans when returning Azure OpenAI accounts

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68b64cda318083278f0908ef18e8badb