### PR TITLE
fix: handle boolean account flags in OpenAI scheduler

### DIFF
--- a/src/services/unifiedOpenAIScheduler.js
+++ b/src/services/unifiedOpenAIScheduler.js
@@ -34,7 +34,7 @@ class UnifiedOpenAIScheduler {
 
         // 普通专属账户
         const boundAccount = await openaiAccountService.getAccount(apiKeyData.openaiAccountId)
-        if (boundAccount && boundAccount.isActive === 'true' && boundAccount.status !== 'error') {
+        if (boundAccount && boundAccount.isActive && boundAccount.status !== 'error') {
           // 检查是否被限流
           const isRateLimited = await this.isAccountRateLimited(boundAccount.id)
           if (isRateLimited) {
@@ -165,7 +165,7 @@ class UnifiedOpenAIScheduler {
     const openaiAccounts = await openaiAccountService.getAllAccounts()
     for (const account of openaiAccounts) {
       if (
-        account.isActive === 'true' &&
+        account.isActive &&
         account.status !== 'error' &&
         (account.accountType === 'shared' || !account.accountType) && // 兼容旧数据
         this._isSchedulable(account.schedulable)
@@ -233,7 +233,7 @@ class UnifiedOpenAIScheduler {
     try {
       if (accountType === 'openai') {
         const account = await openaiAccountService.getAccount(accountId)
-        if (!account || account.isActive !== 'true' || account.status === 'error') {
+        if (!account || !account.isActive || account.status === 'error') {
           return false
         }
         // 检查是否可调度
@@ -395,7 +395,7 @@ class UnifiedOpenAIScheduler {
         const account = await openaiAccountService.getAccount(memberId)
         if (
           account &&
-          account.isActive === 'true' &&
+          account.isActive &&
           account.status !== 'error' &&
           this._isSchedulable(account.schedulable)
         ) {


### PR DESCRIPTION
## Summary
- ensure OpenAI scheduler treats `isActive` as boolean to match account service

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68b650297bb083278cf080a253468ccf