### PR TITLE
fix: handle boolean account flags in OpenAI scheduler

### DIFF
--- a/src/services/unifiedOpenAIScheduler.js
+++ b/src/services/unifiedOpenAIScheduler.js
@@ -34,7 +34,11 @@ class UnifiedOpenAIScheduler {
 
         // 普通专属账户
         const boundAccount = await openaiAccountService.getAccount(apiKeyData.openaiAccountId)
-        if (boundAccount && boundAccount.isActive && boundAccount.status !== 'error') {
+        if (
+          boundAccount &&
+          (boundAccount.isActive === true || boundAccount.isActive === 'true') &&
+          boundAccount.status !== 'error'
+        ) {
           // 检查是否被限流
           const isRateLimited = await this.isAccountRateLimited(boundAccount.id)
           if (isRateLimited) {


### PR DESCRIPTION
## Summary
- ensure `isActive` string values are properly checked when selecting dedicated accounts

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68b651fd1a408327a1843424825aa448