### PR TITLE
Main um 8: align delete API key UI with server config

### DIFF
--- a/web/admin-spa/src/components/user/UserApiKeysManager.vue
+++ b/web/admin-spa/src/components/user/UserApiKeysManager.vue
@@ -259,7 +259,7 @@ const userStore = useUserStore()
 const loading = ref(true)
 const apiKeys = ref([])
 const maxApiKeys = computed(() => userStore.config?.maxApiKeysPerUser || 5)
-const allowUserDeleteApiKeys = computed(() => userStore.config?.allowUserDeleteApiKeys !== false)
+const allowUserDeleteApiKeys = computed(() => userStore.config?.allowUserDeleteApiKeys === true)
 
 const showCreateModal = ref(false)
 const showViewModal = ref(false)


### PR DESCRIPTION
## Summary
- default user API key delete button only when config explicitly true

## Testing
- `npm test -- --passWithNoTests`
- `cd web/admin-spa && npx eslint src/components/user/UserApiKeysManager.vue`


------
https://chatgpt.com/codex/tasks/task_b_68b6fd9dfcc483279693e089e97adf5e